### PR TITLE
Fix techdocs plugin generating loads of unnecessary files

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -36,13 +36,8 @@ class TechDocsCore(BasePlugin):
 
         # Theme
         config["theme"] = Theme(
-            name="material",
-            static_templates=[
-                "techdocs_metadata.json",
-            ],
+            name="material", static_templates=["techdocs_metadata.json",],
         )
-        config["theme"].dirs.append(tempfile.gettempdir())
-
         # Plugins
         del config["plugins"]["techdocs-core"]
 


### PR DESCRIPTION
Adding a temporary directory to list of theme plugin directories
causes havoc by making it walk temporary directories for themes