### PR TITLE
Upgrade plantuml-markdown to 3.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Extensions:
 
 ## Changelog
 
+### 0.0.14
+
+- Upgrade plantuml-markdown to 3.4.2 with support for external file sources. [#18](https://github.com/backstage/mkdocs-techdocs-core/pull/18)
+
 ### 0.0.13
 
 - Fixed issue where the whole temp directory could be included in the built site output. [#7](https://github.com/backstage/mkdocs-techdocs-core/issues/7)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 mkdocs==1.1.2
 mkdocs-material==5.3.2
 mkdocs-monorepo-plugin==0.4.5
-plantuml-markdown==3.1.2
+plantuml-markdown==3.4.2
 markdown_inline_graphviz_extension==1.1
 pygments==2.6.1
 pymdown-extensions==7.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(path.join(this_dir, "README.md"), encoding="utf-8") as file:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.0.13",
+    version="0.0.14",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,
@@ -38,7 +38,7 @@ setup(
         "mkdocs>=1.1.2",
         "mkdocs-material==5.3.2",
         "mkdocs-monorepo-plugin==0.4.5",
-        "plantuml-markdown==3.1.2",
+        "plantuml-markdown==3.4.2",
         "markdown_inline_graphviz_extension==1.1",
         "pygments==2.6.1",
         "pymdown-extensions==7.1",


### PR DESCRIPTION
The plantuml-markdown module has received a handful of bug fixes and new features. This change upgrades it to the latest version available.

Notable changes are the possibility for including plantuml files from files introduced in 3.3.0.

Complete changelog available here: https://github.com/mikitex70/plantuml-markdown/blob/master/CHANGELOG.md