### PR TITLE
Version bump: mkdocs-monorepo-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Extensions:
 
 ## Changelog
 
+### 0.0.15
+
+- Upgrade monorepo to track latest patch, includes various bug fixes. [#22](https://github.com/backstage/mkdocs-techdocs-core/pull/22)
+
 ### 0.0.14
 
 - Upgrade plantuml-markdown to 3.4.2 with support for external file sources. [#18](https://github.com/backstage/mkdocs-techdocs-core/pull/18)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # https://github.com/mkdocs/mkdocs
 mkdocs==1.1.2
 mkdocs-material==5.3.2
-mkdocs-monorepo-plugin==0.4.5
+mkdocs-monorepo-plugin~=0.4.13
 plantuml-markdown==3.4.2
 markdown_inline_graphviz_extension==1.1
 pygments==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(path.join(this_dir, "README.md"), encoding="utf-8") as file:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.0.14",
+    version="0.0.15",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         "mkdocs>=1.1.2",
         "mkdocs-material==5.3.2",
-        "mkdocs-monorepo-plugin==0.4.5",
+        "mkdocs-monorepo-plugin~=0.4.13",
         "plantuml-markdown==3.4.2",
         "markdown_inline_graphviz_extension==1.1",
         "pygments==2.6.1",


### PR DESCRIPTION
Bumps monorepo plugin to latest and keeps up to date with patch versions. 

This will include a few bug fixes (such as those needed for the [compatibility issue with mkdocs-git-revision-date-localized-plugin](https://github.com/backstage/mkdocs-monorepo-plugin/issues/12).