### PR TITLE
Upgrade mkdocs-material to 7.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Extensions:
 
 ## Changelog
 
+### 0.0.16
+
+- Upgrade `mkdocs-material` to latest version (`7.1.0`).
+
 ### 0.0.15
 
 - Upgrade monorepo to track latest patch, includes various bug fixes. [#22](https://github.com/backstage/mkdocs-techdocs-core/pull/22)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Note: if you update this, also update `install_requires` in setup.py
 # https://github.com/mkdocs/mkdocs
 mkdocs==1.1.2
-mkdocs-material==5.3.2
+mkdocs-material==7.1.0
 mkdocs-monorepo-plugin~=0.4.13
 plantuml-markdown==3.4.2
 markdown_inline_graphviz_extension==1.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(path.join(this_dir, "README.md"), encoding="utf-8") as file:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.0.15",
+    version="0.0.16",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,
@@ -36,7 +36,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "mkdocs>=1.1.2",
-        "mkdocs-material==5.3.2",
+        "mkdocs-material==7.1.0",
         "mkdocs-monorepo-plugin~=0.4.13",
         "plantuml-markdown==3.4.2",
         "markdown_inline_graphviz_extension==1.1",


### PR DESCRIPTION
I've tested this on a test doc I have. It looks the same for the most part. The only problem I see is that syntax highlighting is no longer working.

This patch (running on localhost):

![Screenshot 2021-04-09 at 22 41 17](https://user-images.githubusercontent.com/562403/114243570-b8cb5c00-9984-11eb-8f93-583a9dfd7719.png)

The previous release, running on a server (see: https://demo.roadie.so/catalog/default/component/sample-service-1/docs/feature-testing/)

![Screenshot 2021-04-09 at 22 41 57](https://user-images.githubusercontent.com/562403/114243626-d00a4980-9984-11eb-9570-c09c3f61a6eb.png)

Best I can tell, this is because they started using CSS variables to define the syntax colors.

This patch (running on localhost). See the `var(--md-code-fg-color)` in the styles panel.

![Screenshot 2021-04-09 at 22 44 09](https://user-images.githubusercontent.com/562403/114243792-24adc480-9985-11eb-9986-008fec86a428.png)

The previous release, with the same token highlighted.

![Screenshot 2021-04-09 at 22 45 17](https://user-images.githubusercontent.com/562403/114243865-4ad36480-9985-11eb-991e-9f5c3c5f6aec.png)

Here's the [upgrade guide](https://squidfunk.github.io/mkdocs-material/upgrading/) for `mkdocs-material`. We're going through 2 major bumps. `5.x -> 7.1.0`.

I'm working through this in order to try and find the root cause for https://github.com/backstage/backstage/issues/5276 and https://github.com/backstage/backstage/issues/5264