### PR TITLE
Loosen the pinned version requirement for Markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # The "base" version of the Mkdocs project.
 # https://github.com/mkdocs/mkdocs
-mkdocs>=1.2.1
+mkdocs>=1.2.2
 mkdocs-material==5.3.2
 mkdocs-monorepo-plugin~=0.4.13
 plantuml-markdown==3.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # The "base" version of the Mkdocs project.
 # Note: if you update this, also update `install_requires` in setup.py
 # https://github.com/mkdocs/mkdocs
-mkdocs==1.1.2
+mkdocs>=1.2.1
 mkdocs-material==5.3.2
 mkdocs-monorepo-plugin~=0.4.13
 plantuml-markdown==3.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ plantuml-markdown==3.4.2
 markdown_inline_graphviz_extension==1.1
 pygments==2.7.4
 pymdown-extensions==7.1
-Markdown==3.2.2
+Markdown>=3.2,<4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # The "base" version of the Mkdocs project.
-# Note: if you update this, also update `install_requires` in setup.py
 # https://github.com/mkdocs/mkdocs
 mkdocs>=1.2.1
 mkdocs-material==5.3.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.0.16",
+    version="0.1.0",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
Fixes: #26 

Since requirements.txt is directly used by setup.py this constrains this package too much
when combined with other packages that require a newer version of Markdown.