### PR TITLE
Document PlantUML limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Extensions:
   Activate the inline_graphviz extension using the [usage instructions](https://github.com/sprin/markdown-inline-graphviz#usage).
 
 - [plantuml_markdown](https://pypi.org/project/plantuml-markdown/): This plugin implements a block extension which can be used to specify a PlantUML diagram which will be converted into an image and inserted in the document.
+  - Note that the format `svg_object` is not supported for rendering diagrams. Read more in the [TechDocs troubleshooting](https://backstage.io/docs/features/techdocs/troubleshooting#plantuml-with-svg_object-doesnt-render) section.
 
 ## Changelog
 


### PR DESCRIPTION
Currently it is not possible to use the PlantUML format 'svg_object' as this
makes it possible for bad actors to inject malicious content into documentation.

This change adds a link to the plantuml_markdown extension bullet with a link to
the TechDocs troubleshooting section explaining this limitation.

Related to issue backstage/backstage#6232 and docs PR backstage/backstage#6332.

I'm a bit unsure whether the link is correct, so we should wait with merging this until the docs PR is merged to main.