### PR TITLE
Fix monorepo plugin incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Extensions:
 
 ## Changelog
 
+### 0.1.1
+
+- Ensure required mkdocs-monorepo-plugin is compatible with Mkdocs `1.2.x`.
+
 ### 0.1.0
 
 - Improved dependency compatibility with other mkdocs plugins.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # https://github.com/mkdocs/mkdocs
 mkdocs>=1.2.2
 mkdocs-material==5.3.2
-mkdocs-monorepo-plugin~=0.4.13
+mkdocs-monorepo-plugin~=0.4.16
 plantuml-markdown==3.4.2
 markdown_inline_graphviz_extension==1.1
 pygments==2.7.4

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.1.0",
+    version="0.1.1",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
Follow-up to backstage/mkdocs-monorepo-plugin#53 and prerequisite to backstage/techdocs-container#15