### PR TITLE
Fix SVG parsing used by GraphViz

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Extensions:
 
 ## Changelog
 
+### 0.1.2
+
+- Fix the dependency version of Markdown to ensure GraphViz SVG rendering works.
+
 ### 0.1.1
 
 - Ensure required mkdocs-monorepo-plugin is compatible with Mkdocs `1.2.x`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ plantuml-markdown==3.4.2
 markdown_inline_graphviz_extension==1.1
 pygments==2.7.4
 pymdown-extensions==7.1
-Markdown>=3.2,<4.0
+Markdown==3.2.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.1.1",
+    version="0.1.2",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
Fixes: #36 

Signed-off-by: Camila Loiola <camilal@spotify.com>

Markdown>=3.3 is parsing SVG tags incorrectly because it wraps the child SVG tags with `<p></p>` which breaks the rendering of these images.

![image](https://user-images.githubusercontent.com/6290749/129491151-373e11d0-eb4e-40d1-a094-d89d6fd649e0.png)

To avoid it, we've fixed the Markdown version to 3.2.2 and now SVGs are being rendered correctly:

![image](https://user-images.githubusercontent.com/6290749/129490914-ce10cacc-3aee-49f7-b30c-c59625f01e4e.png)
