### PR TITLE
Add mdx-truly-sane-lists to techdocs-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,13 @@ Extensions:
 - [plantuml_markdown](https://pypi.org/project/plantuml-markdown/): This plugin implements a block extension which can be used to specify a PlantUML diagram which will be converted into an image and inserted in the document.
   - Note that the format `svg_object` is not supported for rendering diagrams. Read more in the [TechDocs troubleshooting](https://backstage.io/docs/features/techdocs/troubleshooting#plantuml-with-svg_object-doesnt-render) section.
 
+- [mdx_truly_sane_lists](https://pypi.org/project/mdx-truly-sane-lists/): An extension for Python-Markdown that makes lists truly sane. Features custom indents for nested lists and fix for messy linebreaks and paragraphs between lists.
+
 ## Changelog
+
+### 0.2.0
+
+- Add mdx_truly_sane_lists for dealing with the very annoying bullet differences in mkdocs vs commonmark / gf markdown. See https://github.com/backstage/backstage/issues/6057#issuecomment-862822002
 
 ### 0.1.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ mkdocs-material==5.3.2
 mkdocs-monorepo-plugin~=0.4.16
 plantuml-markdown==3.4.2
 markdown_inline_graphviz_extension==1.1
-mdx_truly_sane_lists=1.2
+mdx_truly_sane_lists==1.2
 pygments==2.7.4
 pymdown-extensions==7.1
 Markdown==3.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ mkdocs-material==5.3.2
 mkdocs-monorepo-plugin~=0.4.16
 plantuml-markdown==3.4.2
 markdown_inline_graphviz_extension==1.1
+mdx_truly_sane_lists=1.2
 pygments==2.7.4
 pymdown-extensions==7.1
 Markdown==3.2.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.1.2",
+    version="0.2.0",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,

--- a/src/core.py
+++ b/src/core.py
@@ -105,6 +105,7 @@ class TechDocsCore(BasePlugin):
 
         config["markdown_extensions"].append("markdown_inline_graphviz")
         config["markdown_extensions"].append("plantuml_markdown")
+        config["markdown_extensions"].append("mdx_truly_sane_lists")
 
         # merge config supplied by user in the mkdocs.yml
         for key in mdx_configs_override:

--- a/src/test_core.py
+++ b/src/test_core.py
@@ -29,6 +29,7 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertTrue("toc" in final_config["mdx_configs"])
         self.assertTrue("permalink" in final_config["mdx_configs"]["toc"])
         self.assertTrue("toc_depth" in final_config["mdx_configs"]["toc"])
+        self.assertTrue("mdx_truly_sane_lists" in final_config["markdown_extensions"])
 
     def test_override_default_config_with_user_config(self):
         self.mkdocs_yaml_config["markdown_extension"] = []
@@ -39,3 +40,4 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertTrue("toc" in final_config["mdx_configs"])
         self.assertTrue("permalink" in final_config["mdx_configs"]["toc"])
         self.assertFalse(final_config["mdx_configs"]["toc"]["permalink"])
+        self.assertTrue("mdx_truly_sane_lists" in final_config["markdown_extensions"])


### PR DESCRIPTION
Based on the discussion in https://github.com/backstage/backstage/issues/6057
add mdx-truly-sane-lists to techdocs-core. This can help address
some of the issues of dealing with the differences between mkdocs and
commonmark/gf markdown in lists