### PR TITLE
Bump package to v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Extensions:
 
 ## Changelog
 
+### 0.2.2
+
+- Update plantuml-md version to 3.5.0 for image maps support
+
 ### 0.2.1
 
 - Fix run-time `module 'pyparsing' has no attribute 'downcaseTokens'` error as

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Extensions:
 
 ### 0.2.2
 
-- Update plantuml-md version to 3.5.0 for image maps support
+- Update `plantuml-markdown` version to 3.5.0 for image maps support
 
 ### 0.2.1
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.2.1",
+    version="0.2.2",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
A new version of the package wasn't released after the [latest change](https://github.com/backstage/mkdocs-techdocs-core/pull/46/files), as the version in `setup.py` was not bumped. 

This PR bumps the version to v0.2.2

Ref: https://discord.com/channels/687207715902193673/714754240933003266/925700071822065665