### PR TITLE
Bump mkdocs-material package

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Extensions:
 
 ## Changelog
 
+### 1.0.1
+
+Upgrade mkdocs-material to [v8.2.7](https://github.com/squidfunk/mkdocs-material/releases/tag/8.2.7)
+
 ### 1.0.0
 
 - This package has been promoted to v1.0!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # The "base" version of the Mkdocs project.
 # https://github.com/mkdocs/mkdocs
 mkdocs>=1.2.2
-mkdocs-material==8.1.11
+mkdocs-material==8.2.7
 mkdocs-monorepo-plugin~=0.5.1
 plantuml-markdown==3.5.0
 pyparsing==2.4.7 # Workaround for run-time error "module 'pyparsing' has no attribute 'downcaseTokens'"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.0.0",
+    version="1.0.1",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
[Releases](https://github.com/squidfunk/mkdocs-material/releases) [8.2.7](https://github.com/squidfunk/mkdocs-material/releases/tag/8.2.7)

> Temporarily limit Jinja version range to < 3.1 due to breaking changes (see https://github.com/mkdocs/mkdocs/issues/2794[](https://github.com/))


## How to test
1. You can install this package locally using pip and the --editable flag used for making developing Python packages.
`pip install --editable .`
2. use example project and add the plugin to your mkdocs.yml
```
plugins:
  - techdocs-core
```
