### PR TITLE
fix: fix broken template_metadata.json for multiline strings

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -35,7 +35,8 @@ class TechDocsCore(BasePlugin):
             "w+",
         ) as fp:
             fp.write(
-                '{\n  "site_name": "{{ config.site_name }}",\n  "site_description": "{{ config.site_description }}"\n}'
+                '{{ {"site_name": (config.site_name | string), '
+                '"site_description": (config.site_description | string)} | tojson }}'
             )
 
         mdx_configs_override = {}

--- a/src/test_core.py
+++ b/src/test_core.py
@@ -1,6 +1,8 @@
 import unittest
 import mkdocs.plugins as plugins
 from .core import TechDocsCore
+from jinja2 import Environment, PackageLoader, select_autoescape
+import json
 
 
 class DummyTechDocsCorePlugin(plugins.BasePlugin):
@@ -40,3 +42,18 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertTrue("permalink" in final_config["mdx_configs"]["toc"])
         self.assertFalse(final_config["mdx_configs"]["toc"]["permalink"])
         self.assertTrue("mdx_truly_sane_lists" in final_config["markdown_extensions"])
+
+    def test_template_renders__multiline_value_as_valid_json(self):
+        self.techdocscore.on_config(self.mkdocs_yaml_config)
+        env = Environment(
+            loader=PackageLoader("test", self.techdocscore.tmp_dir_techdocs_theme.name),
+            autoescape=select_autoescape(),
+        )
+        template = env.get_template("techdocs_metadata.json")
+        config = {
+            "site_name": "my site",
+            "site_description": "my very\nlong\nsite\ndescription",
+        }
+        rendered = template.render(config=config)
+        as_json = json.loads(rendered)
+        self.assertEquals(config, as_json)


### PR DESCRIPTION
Before, the jinja template was constructing the output JSON
manually injecting values from the `config` object as simple
values.

This worked well as long as the values did not contain
any special characters like newlines.
Hence, it causes invalid JSON to be rendered in case of
multiline strings as values, e.g. passed as argument for
`site_description` which was the use case at the bug report
at [backstage/backstage issue #10277](https://github.com/backstage/backstage/issues/10277).
Other special characters like double-quotes could have caused
a similar effect.

This change introduces a test to reproduce the case
and provides a new jinja template which makes use of
the `tojson` filter introduced in jinja 2 to generate
valid JSON.

As previously, the values have been expected to be of type
string, the `string` filter is used for values on top to
guarantee this. (E.g., a numeric value passed as value
would still result in a string value at the rendered JSON.)

Closes: #57
Relates-to: [backstage/backstage issue #10277](https://github.com/backstage/backstage/issues/10277)
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>