### PR TITLE
feat: add language class to code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,13 @@ Extensions:
 
 ## Changelog
 
+### 1.0.2
+
+- Bumped `pymdown-extensions` to 9.3 and enabled `pygments_lang_class` to allow easier targeting of codeblocks by language in TechDocs Addons.
+
 ### 1.0.1
 
-`Jinja2` pinned to v3.0.3. 
+- `Jinja2` pinned to v3.0.3.
 
 ### 1.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pyparsing==2.4.7 # Workaround for run-time error "module 'pyparsing' has no attr
 markdown_inline_graphviz_extension==1.1
 mdx_truly_sane_lists==1.2
 pygments==2.10
-pymdown-extensions==9.0
+pymdown-extensions==9.3
 Markdown==3.2.2
 Jinja2==3.0.3

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.0.1",
+    version="1.0.2",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,

--- a/src/core.py
+++ b/src/core.py
@@ -89,6 +89,7 @@ class TechDocsCore(BasePlugin):
         config["markdown_extensions"].append("pymdownx.highlight")
         config["mdx_configs"]["pymdownx.highlight"] = {
             "linenums": True,
+            "pygments_lang_class": True,
         }
         config["markdown_extensions"].append("pymdownx.extra")
         config["mdx_configs"]["pymdownx.betterem"] = {


### PR DESCRIPTION
Simplify custom processing of code blocks by telling pymdown to add the language as class.

This option was added in `pymdown-extensions` [9.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.2) https://github.com/facelessuser/pymdown-extensions/pull/1596, but I've bumped to 9.3 instead, which is the last version that still supports pygments < 2.12

Related discussion: https://github.com/backstage/backstage/issues/4123#issuecomment-1111530166, cc @iamEAP 
