### PR TITLE
Fix run-time `AttributeError: 'Theme' object has no attribute 'copy'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ## Changelog
 
+### 1.1.1
+
+- Fix run-time `AttributeError: 'Theme' object has no attribute 'copy'`
+
 ### 1.1.0
 
 - Add new capability to override mkdocs theme attributes

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.1.0",
+    version="1.1.1",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,

--- a/src/core.py
+++ b/src/core.py
@@ -46,7 +46,7 @@ class TechDocsCore(BasePlugin):
         # Theme
         theme_override = {}
         if "theme" in config:
-            theme_override = config["theme"].copy()
+            theme_override = config["theme"]
 
         config["theme"] = Theme(
             name="material",


### PR DESCRIPTION
This PR fix the preview #61 

Also the Theme has attributes like this

```
Theme(name='mkdocs', dirs=['/home/aladjadj/.local/lib/python3.10/site-packages/mkdocs/themes/mkdocs', '/home/aladjadj/.local/lib/python3.10/site-packages/mkdocs/templates'], static_templates=['sitemap.xml', '404.html'], locale=Locale('en'), include_search_page=False, search_index_only=False, highlightjs=True, hljs_languages=[], hljs_style='github', navigation_depth=2, nav_style='primary', analytics={'gtag': None}, shortcuts={'help': 191, 'next': 78, 'previous': 80, 'search': 83})
```