### PR TITLE
Fix `'Theme' object has no attribute 'copy'` 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: ci-python-unittest
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Test with unittest
+        run: |
+          python -m unittest src/test_core.py

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ## Changelog
 
+### 1.1.1
+
+- Fix run-time `AttributeError: 'Theme' object has no attribute 'copy'`
+
 ### 1.1.0
 
 - Add new capability to override mkdocs theme attributes

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.1.0",
+    version="1.1.1",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,

--- a/src/core.py
+++ b/src/core.py
@@ -46,7 +46,7 @@ class TechDocsCore(BasePlugin):
         # Theme
         theme_override = {}
         if "theme" in config:
-            theme_override = config["theme"].copy()
+            theme_override = config["theme"]
 
         config["theme"] = Theme(
             name="material",

--- a/src/test_core.py
+++ b/src/test_core.py
@@ -1,8 +1,14 @@
 import unittest
 import mkdocs.plugins as plugins
+from mkdocs.theme import Theme
 from .core import TechDocsCore
 from jinja2 import Environment, PackageLoader, select_autoescape
 import json
+
+# Helper to get the "default" theme passed into config when no theme is
+# provided in the actual config.
+def get_default_theme():
+    return Theme(name="mkdocs")
 
 
 class DummyTechDocsCorePlugin(plugins.BasePlugin):
@@ -16,6 +22,8 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         plugin = DummyTechDocsCorePlugin()
         self.plugin_collection["techdocs-core"] = plugin
         self.mkdocs_yaml_config = {"plugins": self.plugin_collection}
+        # Note: in reality, config["theme"] is always an instance of Theme
+        self.mkdocs_yaml_config["theme"] = get_default_theme()
 
     def test_removes_techdocs_core_plugin_from_config(self):
         final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)


### PR DESCRIPTION
## What / Why

Bug-fix only alternative to #67, including:

- Adds unit test runs in CI
- Ensures tests related to theme override run realistically (`Theme` instance passed to `config["theme"]`, rather than a dict)
- Only resolves the runtime error (there are likely still issues with the underlying override functionality, but this is the quickest way to resolve the build-blocking bug)