### PR TITLE
Bump 'plantuml-markdown' to 3.5.1 to Remove 'uuid' Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ## Changelog
 
+### 1.1.3
+
+- Upgraded `plantuml-markdown` to `3.5.1`, which removes `uuid` as a dependency.
+
 ### 1.1.2
 
 - Simplify theme code to update only the attribute necessary by backstage.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 mkdocs>=1.2.2
 mkdocs-material==8.1.11
 mkdocs-monorepo-plugin~=1.0.1
-plantuml-markdown==3.5.0
+plantuml-markdown==3.5.1
 pyparsing==2.4.7 # Workaround for run-time error "module 'pyparsing' has no attribute 'downcaseTokens'"
 markdown_inline_graphviz_extension==1.1
 mdx_truly_sane_lists==1.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.1.2",
+    version="1.1.3",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
`mkdocs-techdocs-core` currently has a dependency on 'uuid==1.30'. This package does not provide a license which is problematic when using tools that enforce license validation. https://pypi.org/project/uuid/

It seems this dependency is not needed when using Python >= 2.5 anyways. Since `mkdocs-techdocs-core` requires Python >= 3.7, this shouldn't be a problem.

Context:
https://github.com/mikitex70/plantuml-markdown/pull/60
https://github.com/mikitex70/plantuml-markdown/compare/3.5.0...3.5.1

Update:
Found this [README](http://zesty.ca/python/uuid.README.txt) which seems to indicate the library falls under the 'Python Software Foundation License 2'. Regardless, this dependency is not needed.