### PR TITLE
Update markdown >3.2 and graphviz extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 - Add support to Python 3.10 [#73](https://github.com/backstage/mkdocs-techdocs-core/pull/73)
 
+### 1.1.4
+
+- Support markdown version >3.2,<4
+- Use markdown_inline_graphviz_extension 1.1.1 which supports svg rendering for markdown >=3.3
+
 ### 1.1.3
 
 - Upgraded `plantuml-markdown` to `3.5.1`, which removes `uuid` as a dependency.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ mkdocs-material==8.1.11
 mkdocs-monorepo-plugin~=1.0.1
 plantuml-markdown==3.5.1
 pyparsing==2.4.7 # Workaround for run-time error "module 'pyparsing' has no attribute 'downcaseTokens'"
-markdown_inline_graphviz_extension==1.1
+markdown_inline_graphviz_extension>=1.1.1,<2.0
 mdx_truly_sane_lists==1.2
 pygments==2.10
 pymdown-extensions==9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ markdown_inline_graphviz_extension>=1.1.1,<2.0
 mdx_truly_sane_lists==1.2
 pygments==2.10
 pymdown-extensions==9.3
-Markdown==3.2.2
+Markdown>=3.2,<4.0
 Jinja2==3.0.3

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.1.3",
+    version="1.1.4",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
## Summary:

* Update markdown_inline_graphviz_extension to 1.1.1 as errors related to svg rendering is fixed in this [PR](https://github.com/cesaremorel/markdown-inline-graphviz/pull/10)
* The latest version of markdown_inline_graphviz_extension is now compatible with markdown 3.3 and above

**Related to #37** 
**Fixes #36 and #45 (allows users to use markdown >=3.3)**