### PR TITLE
Fix "Error reading page 'index.md': extendMarkdown()"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,12 @@ jobs:
       - name: Test with unittest
         run: |
           python -m unittest src/test_core.py
+      - name: Uninstall dependencies
+        run: |
+          pip list --format=freeze | xargs pip uninstall -y
+      - name: Install techdocs-core plugin.
+        run: |
+          pip install --editable .
+      - name: Run mkdocs build end-to-end
+        run: |
+          mkdocs build --config-file test-fixtures/mkdocs.yml

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ venv.bak/
 
 # mkdocs documentation
 /site
+/test-fixtures/site
 
 # mypy
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -132,9 +132,11 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ## Changelog
 
-### Unreleased
+### 1.1.5
 
-- Add support to Python 3.10 [#73](https://github.com/backstage/mkdocs-techdocs-core/pull/73)
+- Added support for Python 3.10 [#73](https://github.com/backstage/mkdocs-techdocs-core/pull/73)
+- Resolved a run-time error introduced in `1.1.4` that prevented sites from
+  being built under certain circumstances.
 
 ### 1.1.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ markdown_inline_graphviz_extension>=1.1.1,<2.0
 mdx_truly_sane_lists==1.2
 pygments==2.10
 pymdown-extensions==9.3
-Markdown>=3.2,<4.0
+Markdown>=3.2,<3.4
 Jinja2==3.0.3

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.1.4",
+    version="1.1.5",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,

--- a/test-fixtures/docs/index.md
+++ b/test-fixtures/docs/index.md
@@ -1,0 +1,3 @@
+# Home
+
+This is a piece of documentation.

--- a/test-fixtures/mkdocs.yml
+++ b/test-fixtures/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: Fixture Docs
+site_description: Used as a simple end-to-end test of the techdocs-core plugin.
+repo_url: https://github.com/backstage/mkdocs-techdocs-core
+edit_uri: edit/main/test-fixtures/docs
+
+plugins:
+  - techdocs-core
+
+nav:
+  - Home: index.md


### PR DESCRIPTION
## What / Why

Saw reports in discord of folks who merely run `pip install mkdocs-techdocs-core==1.*` in their set up, then run `mkdocs build`, get the following error:

```
ERROR    -  Error reading page 'index.md': extendMarkdown() missing 1 required positional argument: 'md_globals'
mkdocs failed, exit code: 1
```

This PR:
- Adds a simple end-to-end test (run `mkdocs build` after freshly installing this plugin) to catch run-time errors like this.
- Tightens the `Markdown` version constraint to only those versions that are compatible with the current version of `mkdocs`.

Follow-up to #74.

See also: https://github.com/mkdocs/mkdocs/issues/2892