### PR TITLE
[Renovate] Don't pin python packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,10 @@
 {
   labels: ['dependencies'],
   extends: ['config:base', ':disableDependencyDashboard', ':gitSignOff'],
+  packageRules: [
+    {
+      matchLanguages: ['python'],
+      rangeStrategy: 'widen'
+    }
+  ],
 }

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -1,0 +1,20 @@
+name: Validate the renovate configuration
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/renovate.json5'
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Validate
+        uses: rinchsan/renovate-config-validator@v0.0.11
+        with:
+          pattern: '*.json5'


### PR DESCRIPTION
We are more like a library than an end-product, so we need to be able to play well with a range of peer dependencies in the context of someone's mkdocs build environment.

Based on the [docs for `rangeStrategy`](https://docs.renovatebot.com/configuration-options/#rangestrategy), I think we want to `widen` the range.  ...We want to play nicely with any new underlying libraries (if possible).

Once this is in, I'll re-trigger #77.