### PR TITLE
[Renovate] Ignore mkdocs-material

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   labels: ['dependencies'],
   extends: ['config:base', ':disableDependencyDashboard', ':gitSignOff'],
+  ignoreDeps: ['mkdocs-material'],
   packageRules: [
     {
       matchLanguages: ['python'],


### PR DESCRIPTION
## What / Why

Until we have a good process in place to easily test upgrades to `mkdocs-material`, let's ensure renovate doesn't prompt us to upgrade.

Related: #63