### PR TITLE
release v1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ### Unreleased
 
+### 1.1.6
+
 - Removed pins on the `pyparsing` and `Jinja2` dependencies, which are no
   longer needed.
 - Pinned `mkdocs-monorepo-plugin` and `markdown_inline_graphviz_extension` to

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.1.5",
+    version="1.1.6",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
Signed-off-by: Emma Indal <emmai@spotify.com>

Releases: 

- Removed pins on the `pyparsing` and `Jinja2` dependencies, which are no
  longer needed.
- Pinned `mkdocs-monorepo-plugin` and `markdown_inline_graphviz_extension` to
  specific (latest) releases to improve stability. Going forward, these (along
  with all other feature-related deps) will be bumped regularly and any changes
  will be reflected in this changelog.
