### PR TITLE
chore(deps): update dependency mkdocs-monorepo-plugin to v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ### Unreleased
 
+### 1.1.7
+
+- Updated `mkdocs-monorepo-plugin` to `1.0.4`, which includes a compatibility
+  fix for `mkdocs` versions `1.4.0` and newer.
+
 ### 1.1.6
 
 - Removed pins on the `pyparsing` and `Jinja2` dependencies, which are no

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Markdown>=3.2,<3.4
 # explaining what was added or fixed (or at least pointing to the underlying
 # release notes of the bumped package).
 mkdocs-material==8.1.11
-mkdocs-monorepo-plugin==1.0.3
+mkdocs-monorepo-plugin==1.0.4
 plantuml-markdown==3.5.1
 markdown_inline_graphviz_extension==1.1.1
 mdx_truly_sane_lists==1.3

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.1.6",
+    version="1.1.7",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
## What / Why

Fixes an incompatibility between this package and mkdocs v1.4.0 (see https://github.com/backstage/mkdocs-monorepo-plugin/pull/86)