### PR TITLE
feat(redirects): add support for redirects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ Markdown>=3.2,<3.4
 # release notes of the bumped package).
 mkdocs-material==8.1.11
 mkdocs-monorepo-plugin==1.0.4
+mkdocs-techdocs-redirects==0.1.1
 plantuml-markdown==3.5.1
 markdown_inline_graphviz_extension==1.1.1
 mdx_truly_sane_lists==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Markdown>=3.2,<3.4
 # release notes of the bumped package).
 mkdocs-material==8.1.11
 mkdocs-monorepo-plugin==1.0.4
-mkdocs-techdocs-redirects==0.1.2
+mkdocs-redirects==1.2.0
 plantuml-markdown==3.5.1
 markdown_inline_graphviz_extension==1.1.1
 mdx_truly_sane_lists==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Markdown>=3.2,<3.4
 # release notes of the bumped package).
 mkdocs-material==8.1.11
 mkdocs-monorepo-plugin==1.0.4
-mkdocs-techdocs-redirects==0.1.1
+mkdocs-techdocs-redirects==0.1.2
 plantuml-markdown==3.5.1
 markdown_inline_graphviz_extension==1.1.1
 mdx_truly_sane_lists==1.3

--- a/src/core.py
+++ b/src/core.py
@@ -22,7 +22,7 @@ from mkdocs.theme import Theme
 from mkdocs.utils import warning_filter
 from mkdocs.contrib.search import SearchPlugin
 from mkdocs_monorepo_plugin.plugin import MonorepoPlugin
-from techdocs_redirects.plugin import RedirectPlugin
+from mkdocs_redirects.plugin import RedirectPlugin
 from pymdownx.emoji import to_svg
 
 log = logging.getLogger(__name__)

--- a/src/core.py
+++ b/src/core.py
@@ -22,6 +22,7 @@ from mkdocs.theme import Theme
 from mkdocs.utils import warning_filter
 from mkdocs.contrib.search import SearchPlugin
 from mkdocs_monorepo_plugin.plugin import MonorepoPlugin
+from techdocs_redirects.plugin import RedirectPlugin
 from pymdownx.emoji import to_svg
 
 log = logging.getLogger(__name__)
@@ -70,8 +71,13 @@ class TechDocsCore(BasePlugin):
 
         monorepo_plugin = MonorepoPlugin()
         monorepo_plugin.load_config({})
+
+        redirects_plugin = RedirectPlugin()
+        redirects_plugin.load_config({})
+
         config["plugins"]["search"] = search_plugin
         config["plugins"]["monorepo"] = monorepo_plugin
+        config["plugins"]["redirects"] = redirects_plugin
 
         # Markdown Extensions
         if "markdown_extensions" not in config:
@@ -79,6 +85,11 @@ class TechDocsCore(BasePlugin):
 
         if "mdx_configs" not in config:
             config["mdx_configs"] = {}
+
+        # in the future, we may decide to interpret redirects from somewhere else than mkdocs.yaml
+        # redirects.redirect_maps.{}
+        if "redirects" not in config:
+            config["redirects"] = {}
 
         config["markdown_extensions"].append("admonition")
         config["markdown_extensions"].append("toc")

--- a/test-fixtures/docs/other.md
+++ b/test-fixtures/docs/other.md
@@ -1,0 +1,3 @@
+# Other page
+
+This is another beautiful page of documentation.

--- a/test-fixtures/docs/target.md
+++ b/test-fixtures/docs/target.md
@@ -1,0 +1,3 @@
+# Target page
+
+This page is a target for some redirections.

--- a/test-fixtures/mkdocs.yml
+++ b/test-fixtures/mkdocs.yml
@@ -7,7 +7,9 @@ plugins:
   - techdocs-core
   - redirects:
       redirect_maps:
-        homepage: ''
+        homepage.md: ''
+        a_redirection.md: other.md
+        a/deep/non-existent/link.md: target.md
 
 nav:
   - Home: index.md

--- a/test-fixtures/mkdocs.yml
+++ b/test-fixtures/mkdocs.yml
@@ -5,6 +5,9 @@ edit_uri: edit/main/test-fixtures/docs
 
 plugins:
   - techdocs-core
+  - redirects:
+      redirect_maps:
+        homepage: ''
 
 nav:
   - Home: index.md


### PR DESCRIPTION
Updated text:

This adds the mkdocs-redirects plug-in to the TechDocs image so it may be leveraged by the `TechDocsRedirect` backstage add-on.

This also adds a few fixtures to test it. See https://github.com/backstage/backstage/pull/14730 for the backstage PR.

REVISED

original version
This adds redirect stances to the techdocs_metadata.json file so they can be leveraged by Backstage at runtime to perform the redirections on the frontend.

This will be completed by an add-on contribution to backstage itself.