### PR TITLE
chore(deps): update mkdocs-material to v8.5.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,13 +9,13 @@ Markdown>=3.2,<3.4
 # pinned to an exact version. Bumps should be accompanied by release notes
 # explaining what was added or fixed (or at least pointing to the underlying
 # release notes of the bumped package).
-mkdocs-material==8.1.11
+mkdocs-material==8.5.9
 mkdocs-monorepo-plugin==1.0.4
 plantuml-markdown==3.5.1
 markdown_inline_graphviz_extension==1.1.1
 mdx_truly_sane_lists==1.3
-pygments==2.10
-pymdown-extensions==9.3
+pygments==2.12
+pymdown-extensions==9.8
 
 # The following are temporary dependencies that are only necessary to work
 # around incompatible/conflicting underlying dependencies. Each dependency


### PR DESCRIPTION
This change also required updating pygments to v2.12 and pymdown-extensions to v9.8.

A lot of new features have been added to mkdocs-material since 8.1.

In [8.2](https://github.com/squidfunk/mkdocs-material/releases/tag/8.2.0) we got:

- native support for Mermaid.js diagrams
- native support for tags (with search integration)

We use tags a lot in our company, and it was a pain point migrating our mkdocs into backstage. We have a workaround, installing the newer version of mkcdocs-material in the backstage Dockerfile. Still, it is harder to have a good local setup for repos that want to use the techdocs plugin with mkdocs-material.

In [8.3](https://github.com/squidfunk/mkdocs-material/releases/tag/8.3.0) we got:

- support for custom admonition icons
- support for linking of content tabs
- support for boosting pages in search
- support for hiding footer navigation
- previous/next indicators to content tabs
- Improved typeset link colors in light and dark mode

In [8.4](https://github.com/squidfunk/mkdocs-material/releases/tag/8.4.0) we got:

- support for cookie consent
- support for feedback widget (Was this page helpful?)
- support for dismissable announcement bar

In [8.5](https://github.com/squidfunk/mkdocs-material/releases/tag/8.5.0) we got:

- support for social cards
- support for code annotation anchor links (deep linking)
- support for code annotation comment stripping (syntax modifier)
- support for sidebars scrolling automatically to active item
- support for anchor following table of contents (= auto scroll)
- support for tag icons

If this update could be added, it would make our lives much easier. We have tested this on our instance of backstage and have not identified any breaking changes. 

Thank you!
