### PR TITLE
Bump mkdocs material to v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ### Unreleased
 
+### 1.2.0
+ - Updated `mkdocs-material` (and its dependencies) from `8.1.11` to `9.1.3` causing a few changes:
+   -  Some `mkdocs-material` features were made opt-in v9. In order to preserve compatibility, they are now hardcoded as enabled by `mkdocs-techdocs-core`. The features are
+      -  `navigation.footer`
+      -  `content.action.edit`
+   -  `theme.palette` is now hardcoded for compatibility.
+   -  Some components e.g. admonitions have a slightly different look.
+   -  Minor color changes that can be avoided by also updating to the latest version of `@backstage/plugin-techdocs` which compensates these changes.
+
 ### 1.1.7
 
 - Updated `mkdocs-monorepo-plugin` to `1.0.4`, which includes a compatibility

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,13 +9,13 @@ Markdown>=3.2,<3.4
 # pinned to an exact version. Bumps should be accompanied by release notes
 # explaining what was added or fixed (or at least pointing to the underlying
 # release notes of the bumped package).
-mkdocs-material==8.1.11
+mkdocs-material==9.1.3
 mkdocs-monorepo-plugin==1.0.4
 plantuml-markdown==3.5.1
 markdown_inline_graphviz_extension==1.1.1
 mdx_truly_sane_lists==1.3
-pygments==2.10
-pymdown-extensions==9.3
+pygments==2.14
+pymdown-extensions==9.9.1
 
 # The following are temporary dependencies that are only necessary to work
 # around incompatible/conflicting underlying dependencies. Each dependency

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.1.7",
+    version="2.0.0",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="2.0.0",
+    version="1.2.0",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,

--- a/src/core.py
+++ b/src/core.py
@@ -63,6 +63,9 @@ class TechDocsCore(BasePlugin):
             config["theme"]["features"] = []
 
         config["theme"]["features"].append("navigation.footer")
+        config["theme"]["features"].append("content.action.edit")
+
+        config["theme"]["palette"] = ""
 
         config["theme"].static_templates.update({"techdocs_metadata.json"})
         config["theme"].dirs.append(self.tmp_dir_techdocs_theme.name)

--- a/src/core.py
+++ b/src/core.py
@@ -59,6 +59,11 @@ class TechDocsCore(BasePlugin):
                 TECHDOCS_DEFAULT_THEME,
             )
 
+        if "features" not in config["theme"]:
+            config["theme"]["features"] = []
+
+        config["theme"]["features"].append("navigation.footer")
+
         config["theme"].static_templates.update({"techdocs_metadata.json"})
         config["theme"].dirs.append(self.tmp_dir_techdocs_theme.name)
 


### PR DESCRIPTION
# mkdocs-material 9

This PR bumps `mkdocs-material`, and some of its dependencies, to their latest version.

Please check out the changelog to understand the impact of this change:
https://github.com/backstage/mkdocs-techdocs-core/blob/4925666a9af5933334ae785896bea55fc0ad3ffe/README.md?plain=1#L149-L156

## 🚂 PR Sequence
To distribute this change, there are a few PR:s that should be merged in the following order:

1. `@backstage/plugin-techdocs`: https://github.com/backstage/backstage/pull/17031
2. This PR
3. The 

## 🔧 Upgrading (once all PRs are merged)
To start using `mkdocs-techdocs-core:1.2.0`, these are the recommended steps
1. Upgrade to version `<tbd>` of `@backstage/plugin-techdocs` in your backstage deployment
4. Upgrade your image to `spotify/techdocs:<tbd>`

Related issues: https://github.com/backstage/mkdocs-techdocs-core/issues/108, https://github.com/backstage/mkdocs-techdocs-core/issues/63


