### PR TITLE
Replace markdown_inline_graphviz with mkdocs-graphviz

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,14 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ### Unreleased
 
+- Replace `markdown_inline_graphviz_extension` with `mkdocs-graphviz`, another fork. Notably, this fork removes the conflicting legacy `{% %}` syntax.
+
 ### 1.2.0
  - Updated `mkdocs-material` (and its dependencies) from `8.1.11` to `9.1.3` causing a few changes:
    -  Some `mkdocs-material` features were made opt-in v9. In order to preserve compatibility, they are now hardcoded as enabled by `mkdocs-techdocs-core`. The features are
       -  `navigation.footer`
       -  `content.action.edit`
-   -  `theme.palette` is now hardcoded to `""` to preserve previous behavior. Without hardcoding the palette, it gets the value `default`, causing unwanted visual changes. 
+   -  `theme.palette` is now hardcoded to `""` to preserve previous behavior. Without hardcoding the palette, it gets the value `default`, causing unwanted visual changes.
    -  Some components e.g. admonitions have a slightly different look.
    -  Minor color changes that can be avoided by also updating to the latest version of `@backstage/plugin-techdocs` which compensates these changes.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Markdown>=3.2,<3.4
 mkdocs-material==9.1.3
 mkdocs-monorepo-plugin==1.0.4
 plantuml-markdown==3.5.1
-markdown_inline_graphviz_extension==1.1.1
+mkdocs-graphviz==1.5.3
 mdx_truly_sane_lists==1.3
 pygments==2.14
 pymdown-extensions==9.9.1

--- a/src/core.py
+++ b/src/core.py
@@ -123,7 +123,7 @@ class TechDocsCore(BasePlugin):
         }
         config["markdown_extensions"].append("pymdownx.tilde")
 
-        config["markdown_extensions"].append("markdown_inline_graphviz")
+        config["markdown_extensions"].append("mkdocs_graphviz")
         config["markdown_extensions"].append("plantuml_markdown")
         config["markdown_extensions"].append("mdx_truly_sane_lists")
 


### PR DESCRIPTION
Resolves #102 -- Legacy markdown_inline_graphviz syntax conflicts with other languages used in code blocks due to regular expression matching on `{%`

The optional cdn hosted js for light/dark themes is not loaded by techdocs-core to avoid external dependencies.

Notable visible changes:
* The current mkdocs-techdocs-core renders black on white background by default.
* This PR renders #789ABC by default with no background. This works reasonably well for either light or dark themes in Backstage as seen in the screenshots attached.
* Further customization can be done by the user either in the mkdocs configuration or in the graphviz itself.

To preserve the current defaults we can add the following extension options:

```yaml
markdown_extensions:
  - mkdocs_graphviz:
      color: 000000
      bgcolor: FFFFFF
```

### Current
<img width="360" alt="before" src="https://user-images.githubusercontent.com/746474/234669942-460844b9-ed79-4408-b8f6-983da796b416.png">

### Proposed
<img width="354" alt="after-dark" src="https://user-images.githubusercontent.com/746474/234669960-7043feb1-eb42-40a8-9f25-bdbff3a28b71.png">
<img width="312" alt="after-light" src="https://user-images.githubusercontent.com/746474/234670027-018a2adc-5a4a-4ec6-b8d4-288dc9a7eb0b.png">