### PR TITLE
Update inline graphviz extension 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Markdown>=3.2,<3.4
 mkdocs-material==9.1.3
 mkdocs-monorepo-plugin==1.0.4
 plantuml-markdown==3.5.1
-markdown_inline_graphviz_extension==1.1.1
+markdown_inline_graphviz_extension @ git+https://github.com/cesaremorel/markdown-inline-graphviz@v1.1.2
 mdx_truly_sane_lists==1.3
 pygments==2.14
 pymdown-extensions==9.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Markdown>=3.2,<3.4
 mkdocs-material==9.1.3
 mkdocs-monorepo-plugin==1.0.4
 plantuml-markdown==3.5.1
-markdown_inline_graphviz_extension @ git+https://github.com/cesaremorel/markdown-inline-graphviz@v1.1.2
+markdown_inline_graphviz_extension==1.1.2
 mdx_truly_sane_lists==1.3
 pygments==2.14
 pymdown-extensions==9.9.1


### PR DESCRIPTION
This is a more conservative fix to #113 which will also resolve #102. This issue was apparently fixed years ago in the script, but never published to pypi. The fixed version lives tagged as v1.1.2 while the last published version was v1.1.1.

This fix is backward compatible. 