### PR TITLE
Fix build from sdist

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Build Python distribution
         working-directory: .
         run: |
-          pip install wheel
+          pip install build
           rm -rf dist
-          python setup.py bdist_wheel sdist --formats gztar
+          pyproject-build
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
PR #24 deduplicated the requirements, but this makes the sdist on PyPi fail to build, because requirements.txt is not included.

This fix includes requirements.txt using MANIFEST.in and changes the publication workflow to use build instead of calling setup.py directly. build always builds the wheel from the sdist, so this error is prevented in the future.
