### PR TITLE
Update dependency pygments to v2.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ### Unreleased
 
+### 1.2.2
+ - Updated `pygments` from `2.14` to `2.15.1`
+
 ### 1.2.1
  - Use latest version of `pymdown-extensions` which contains [security fixes](https://github.com/backstage/mkdocs-techdocs-core/pull/123).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ mkdocs-monorepo-plugin==1.0.5
 plantuml-markdown==3.5.1
 markdown_inline_graphviz_extension==1.1.1
 mdx_truly_sane_lists==1.3
-pygments==2.14
+pygments==2.15.1
 pymdown-extensions==10.0.1
 
 # The following are temporary dependencies that are only necessary to work

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.2.1",
+    version="1.2.2",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
A ReDoS issue was discovered in `pygments/lexers/smithy.py` in Pygments until 2.15.0 via SmithyLexer.

https://vuldb.com/?id.235018
https://vulners.com/osv/OSV:GHSA-MRWQ-X4V8-FH7P