### PR TITLE
Reverting Markdown dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # as ranges in order to support interoperability with other mkdocs plugins or
 # packages that might otherwise exist in an adopter's environment.
 mkdocs>=1.2.2
-Markdown>=3.2,<3.5
+Markdown>=3.2,<3.4
 
 # The following are more akin to direct dependencies. Each line represents one
 # or more features that are provided by `techdocs-core`, and thus are always


### PR DESCRIPTION
Reverting Markdown dependency back to `>=3.2,<3.4` as later versions are not compatible with mkdocs