### PR TITLE
Update dependency markdown_inline_graphviz_extension to v1.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Markdown>=3.2,<3.4
 mkdocs-material==9.1.3
 mkdocs-monorepo-plugin==1.0.5
 plantuml-markdown==3.9.2
-markdown_inline_graphviz_extension==1.1.1
+markdown_inline_graphviz_extension==1.1.2
 mdx_truly_sane_lists==1.3
 pygments==2.16.1
 pymdown-extensions==10.0.1


### PR DESCRIPTION
This PR resolves #102. Instead of throwing an exception, the graphviz extension will skip `{%` sequences in markdown. 
See https://github.com/cesaremorel/markdown-inline-graphviz/commit/89a969bb0168501dd5bd2e2c847651422bc6bb52