### PR TITLE
Fix palette property of theme

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -70,7 +70,7 @@ class TechDocsCore(BasePlugin):
         config["theme"]["features"].append("navigation.footer")
         config["theme"]["features"].append("content.action.edit")
 
-        config["theme"]["palette"] = ""
+        config["theme"]["palette"] = {}
 
         config["theme"].static_templates.update({"techdocs_metadata.json"})
         config["theme"].dirs.append(self.tmp_dir_techdocs_theme.name)


### PR DESCRIPTION
The palette property of the material theme expects an object, not an empty string. See [here](https://github.com/squidfunk/mkdocs-material/blob/d7348cc2170a6020e985ce60c8650ae146d1533d/src/mkdocs_theme.yml#L33)  

This seemed to be causing issues with some of the theme features, such as in #128 