### PR TITLE
Bumped the version of the Material theme to 9.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ### Unreleased
 
+### 1.3
+ - Bumped `mkdocs-material` (and its dependencies) from `9.1.3` to `9.2.7` causing a few changes:
+   - MkDocs dependency is now `1.5`
+ - `theme.palette` is now hardcoded to `{}` instead of `""` which caused some issues with some Material plugins
+
 ### 1.2.3
  - Bumped `pygments` to `2.16.1`, which also fixes a [vulnerability](https://github.com/advisories/GHSA-mrwq-x4v8-fh7p).
  - Update dependency `plantuml-markdown` to `3.9.2`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # The following are something akin to peer dependencies. They are represented
 # as ranges in order to support interoperability with other mkdocs plugins or
 # packages that might otherwise exist in an adopter's environment.
-mkdocs>=1.2.2
+mkdocs>=1.5
 Markdown>=3.2,<3.4
 
 # The following are more akin to direct dependencies. Each line represents one
@@ -9,13 +9,13 @@ Markdown>=3.2,<3.4
 # pinned to an exact version. Bumps should be accompanied by release notes
 # explaining what was added or fixed (or at least pointing to the underlying
 # release notes of the bumped package).
-mkdocs-material==9.1.3
+mkdocs-material==9.2.7
 mkdocs-monorepo-plugin==1.0.5
 plantuml-markdown==3.9.2
 markdown_inline_graphviz_extension==1.1.1
 mdx_truly_sane_lists==1.3
 pygments==2.16.1
-pymdown-extensions==10.0.1
+pymdown-extensions==10.2
 
 # The following are temporary dependencies that are only necessary to work
 # around incompatible/conflicting underlying dependencies. Each dependency

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.2.3",
+    version="1.3",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,

--- a/src/core.py
+++ b/src/core.py
@@ -70,7 +70,7 @@ class TechDocsCore(BasePlugin):
         config["theme"]["features"].append("navigation.footer")
         config["theme"]["features"].append("content.action.edit")
 
-        config["theme"]["palette"] = ""
+        config["theme"]["palette"] = {}
 
         config["theme"].static_templates.update({"techdocs_metadata.json"})
         config["theme"].dirs.append(self.tmp_dir_techdocs_theme.name)


### PR DESCRIPTION
I bumped the version of the Material theme to `9.2.7` as requested in #145 

Versions of Material Theme after 9.2 requires `mkdocs>=1.5`, but as there's no upper bound on the version range in [requirements.txt](https://github.com/backstage/mkdocs-techdocs-core/blob/b91a812ea3ee72beaa349cd66674f487d79e2241/requirements.txt#L4) the version resolved already there. I updated the lower bound in this update to ensure that the version is met. 

The version `pymdown-extensions` needed a bump too

`9.2.7` is the highest we can go without requiring a higher version of Python. Version `9.2.8` requires `pymdown-extensions>=10.3` which isn't available for Python 3.7, and likewise `mkdocs-material` after 9.3 requires a higher python version too