### PR TITLE
Update pygments to 2.18.1 to include a jsx lexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ### Unreleased
 
+### 1.3.1
+ - Bumped `pygments` to `2.17.2` which includes JSX support.
+
 ### 1.3
  - Bumped `mkdocs-material` (and its dependencies) from `9.1.3` to `9.2.7` causing a few changes:
    - MkDocs dependency is now `1.5`

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ markdown_inline_graphviz_extension==1.1.2
 mkdocs-monorepo-plugin==1.0.5
 plantuml-markdown==3.9.2
 mdx_truly_sane_lists==1.3
-pygments==2.16.1
+pygments==2.17.2
 pymdown-extensions==10.2
 
 # The following are temporary dependencies that are only necessary to work

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.3",
+    version="1.3.1",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
Pygments 2.17 includes a new lexer for JSX (React) syntax. It doesn't officially support TSX (Typescript React) still but an improvement nonetheless.