### PR TITLE
fix(deprecation): remove warning_filter

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -19,13 +19,11 @@ import logging
 import os
 from mkdocs.plugins import BasePlugin
 from mkdocs.theme import Theme
-from mkdocs.utils import warning_filter
 from mkdocs.contrib.search import SearchPlugin
 from mkdocs_monorepo_plugin.plugin import MonorepoPlugin
 from pymdownx.emoji import to_svg
 
 log = logging.getLogger(__name__)
-log.addFilter(warning_filter)
 
 TECHDOCS_DEFAULT_THEME = "material"
 


### PR DESCRIPTION
```log
INFO    -  DeprecationWarning: warning_filter doesn't do anything since MkDocs 1.2 and will be removed soon. All messages on the `mkdocs` logger get counted automatically.
             File "/Users/mindtooth/Git/docs/linux-mirror/venv/lib/python3.11/site-packages/src/core.py", line 22, in <module>
               from mkdocs.utils import warning_filter
             File "/Users/mindtooth/Git/docs/linux-mirror/venv/lib/python3.11/site-packages/mkdocs/utils/__init__.py", line 453, in __getattr__
               warnings.warn(
```

Stolen from https://github.com/Lisandra-dev/mkdocs-ezlinked-plugin/commit/380116f20898b64bf75b00110e8d61d05aeabc34