### PR TITLE
Bump mkdocs material and include python 3.11 in testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", 3.11]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ### Unreleased
 
+### 1.3.3
+ - Bumped `mkdocs-material` to `9.4.14` which add support for: Mermaid.js version 10.6.1, emoji extension and updated MkDocs to 1.5.3
+ - Added tests for `Python` version `3.11`
+
 ### 1.3.2
  - Bumped `pymdown-extensions` to `10.3.1` which add material.extensions support
  - Removed support for `Python` version `3.7`

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Markdown>=3.2,<3.4
 # pinned to an exact version. Bumps should be accompanied by release notes
 # explaining what was added or fixed (or at least pointing to the underlying
 # release notes of the bumped package).
-mkdocs-material==9.2.7
+mkdocs-material==9.4.14
 markdown_inline_graphviz_extension==1.1.2
 mkdocs-monorepo-plugin==1.0.5
 plantuml-markdown==3.9.2

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.3.2",
+    version="1.3.3",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,
@@ -46,7 +46,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     packages=find_packages(),
     entry_points={"mkdocs.plugins": ["techdocs-core = src.core:TechDocsCore"]},


### PR DESCRIPTION
 - Bumped `mkdocs-material` to `9.4.14` which add support for: Mermaid.js version 10.6.1, emoji extension and updated MkDocs to 1.5.3
 - Added tests for `Python` version `3.11`