### PR TITLE
Bumped the version of mkdocs-material to 9.5.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ### Unreleased
 
+### 1.3.5
+ - Bumped `mkdocs-material` to `9.5.13` which adds support for card grids and grid layouts
+
 ### 1.3.3
  - Bumped `mkdocs-material` to `9.4.14` which add support for: Mermaid.js version 10.6.1, emoji extension and updated MkDocs to 1.5.3
  - Added tests for `Python` version `3.11`

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Markdown>=3.2,<3.4
 # pinned to an exact version. Bumps should be accompanied by release notes
 # explaining what was added or fixed (or at least pointing to the underlying
 # release notes of the bumped package).
-mkdocs-material==9.4.14
+mkdocs-material==9.5.13
 markdown_inline_graphviz_extension==1.1.2
 mkdocs-monorepo-plugin==1.1.0
 plantuml-markdown==3.9.2

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.3.4",
+    version="1.3.5",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
I bumped the version of the Material Theme to `9.5.13` as requested in https://github.com/backstage/mkdocs-techdocs-core/issues/166 adding support for [Grids](https://squidfunk.github.io/mkdocs-material/reference/grids/)