### PR TITLE
Update requirements.txt to allow plantuml-markdown 3.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Markdown>=3.2,<3.4
 mkdocs-material==9.5.13
 markdown_inline_graphviz_extension==1.1.2
 mkdocs-monorepo-plugin==1.1.0
-plantuml-markdown==3.9.2
+plantuml-markdown>=3.9.3
 mdx_truly_sane_lists==1.3
 pymdown-extensions==10.3.1
 pygments==2.17.2


### PR DESCRIPTION
There is now a [plantuml-markdown 3.9.3](https://pypi.org/project/plantuml-markdown/#history), and without this proposed change, I cannot co-install these:
* mkdocs-techdocs-core==1.3.5
* plantuml-markdown==3.9.3

as the following error is thrown:

```
[
  "RequirementInformation(requirement=SpecifierRequirement('plantuml-markdown==3.9.3')",
  "parent=None)",
  "RequirementInformation(requirement=SpecifierRequirement('plantuml-markdown==3.9.2')",
  "parent=LinkCandidate('https://files.pythonhosted.org/packages/b1/14/00c84cda0fc45169e936157ff5a79db22d4f3206df611975f630ffef3f22/mkdocs_techdocs_core-1.3.5-py3-none-any.whl (from https://pypi.org/simple/mkdocs-techdocs-core/) (requires-python:>=3.7)'))"
]
```