### PR TITLE
fix(stale): don't include renovate pr's

### DIFF
--- a/.github/workflows/automate-stale.yml
+++ b/.github/workflows/automate-stale.yml
@@ -18,6 +18,7 @@ jobs:
           days-before-issue-stale: 60
           days-before-issue-close: 7
           exempt-issue-labels: after-vacations,will-fix
+          exempt-pr-labels: dependencies
           stale-issue-label: stale
           stale-pr-message: >
             This PR has been automatically marked as stale because it has not had


### PR DESCRIPTION
I'm not sure why Stale needs to interact with the Renovate PR's.  Or is this by design?

I see that a ton has already been closed without being merged: https://github.com/backstage/mkdocs-techdocs-core/pulls?q=is%3Apr+is%3Aclosed+label%3Astale

Maybe this project needs more reviewers from you guys? :smile: