### PR TITLE
Update mkdocs to 1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # The following are something akin to peer dependencies. They are represented
 # as ranges in order to support interoperability with other mkdocs plugins or
 # packages that might otherwise exist in an adopter's environment.
-mkdocs>=1.5
+mkdocs>=1.6
 Markdown>=3.2,<3.4
 
 # The following are more akin to direct dependencies. Each line represents one


### PR DESCRIPTION
Since mkdocs-material `9.5.19` https://github.com/squidfunk/mkdocs-material/blob/9.5.19/requirements.txt minimum mkdocs is 1.6

Fix #187 