### PR TITLE
Version Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ## Changelog
 
-### Unreleased
+### 1.4.0
+ - Updated minimum mkdocs dependency from `1.5` to `1.6`
+   - Fixes issue [#187](https://github.com/backstage/mkdocs-techdocs-core/issues/187)
+ - mkdocs-material bumped to `9.5.27`
 
 ### 1.3.6
  - Bumped `mkdocs-material` to `9.5.26`.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.3.6",
+    version="1.4.0",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
Version bump for next release.
Bumped to 1.4 since we're now no longer supporting mkdocs below 1.6