### PR TITLE
Optionally use material search

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ plugins:
   - techdocs-core
 ```
 
-(Optional) To use material them search to generate the `search/search_index.json` (responsible for the search functionality in the TechDocs reader), you need to add the following configuration to your `mkdocs.yml`:
+(Optional) To use material theme search to generate the `search/search_index.json` (responsible for the search functionality in the TechDocs reader), you need to add the following configuration to your `mkdocs.yml`:
 
 ```yaml
 plugins:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ plugins:
   - techdocs-core
 ```
 
+(Optional) To use material them search to generate the `search/search_index.json` (responsible for the search functionality in the TechDocs reader), you need to add the following configuration to your `mkdocs.yml`:
+
+```yaml
+plugins:
+  - techdocs-core:
+      use_material_search: true
+```
+
 ## Development
 
 ### Running Locally

--- a/src/core.py
+++ b/src/core.py
@@ -75,7 +75,9 @@ class TechDocsCore(BasePlugin):
         config["theme"].dirs.append(self.tmp_dir_techdocs_theme.name)
 
         # Plugins
-        use_material_search = config["plugins"]["techdocs-core"].config.get("material_search", False)
+        use_material_search = config["plugins"]["techdocs-core"].config.get(
+            "use_material_search", False
+        )
         del config["plugins"]["techdocs-core"]
 
         if use_material_search:

--- a/src/core.py
+++ b/src/core.py
@@ -20,6 +20,7 @@ import os
 from mkdocs.plugins import BasePlugin
 from mkdocs.theme import Theme
 from mkdocs.contrib.search import SearchPlugin
+from material.plugins.search.plugin import SearchPlugin as MaterialSearchPlugin
 from mkdocs_monorepo_plugin.plugin import MonorepoPlugin
 from pymdownx.emoji import to_svg
 
@@ -74,9 +75,13 @@ class TechDocsCore(BasePlugin):
         config["theme"].dirs.append(self.tmp_dir_techdocs_theme.name)
 
         # Plugins
+        use_material_search = config["plugins"]["techdocs-core"].get("material_search", False)
         del config["plugins"]["techdocs-core"]
 
-        search_plugin = SearchPlugin()
+        if use_material_search:
+            search_plugin = MaterialSearchPlugin()
+        else:
+            search_plugin = SearchPlugin()
         search_plugin.load_config({})
 
         monorepo_plugin = MonorepoPlugin()

--- a/src/core.py
+++ b/src/core.py
@@ -75,7 +75,7 @@ class TechDocsCore(BasePlugin):
         config["theme"].dirs.append(self.tmp_dir_techdocs_theme.name)
 
         # Plugins
-        use_material_search = config["plugins"]["techdocs-core"].get("material_search", False)
+        use_material_search = config["plugins"]["techdocs-core"].config.get("material_search", False)
         del config["plugins"]["techdocs-core"]
 
         if use_material_search:

--- a/src/test_core.py
+++ b/src/test_core.py
@@ -111,3 +111,21 @@ class TestTechDocsCoreConfig(unittest.TestCase):
             final_config["mdx_configs"]["pymdownx.snippets"]["restrict_base_path"],
             True,
         )
+
+    def test_material_search(self):
+        self.plugin_collection["techdocs-core"].load_config(
+            {"use_material_search": True}
+        )
+        final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
+
+        self.assertEqual(
+            final_config["plugins"]["search"].__module__,
+            "material.plugins.search.plugin",
+        )
+
+    def test_default_search(self):
+        self.plugin_collection["techdocs-core"].load_config({})
+        final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
+        self.assertEqual(
+            final_config["plugins"]["search"].__module__, "mkdocs.contrib.search"
+        )


### PR DESCRIPTION
fixes: #192 

see also: https://github.com/backstage/backstage/pull/25497

the `search/search_index.json` template behaves differently based on which search plugin is being used.

with this change, we allow users to use material theme's search for generating the index.

Differences:

||Mkdocs search|Material theme search|
|---|---|---|
|Document split|Both entire document and heading sections|Only headings|
|Content escaping|Yes, both title and text|No, only titles. Text still contains html tags|
|Tags support|No|Yes|
|Boost support|No|Yes|