### PR TITLE
Fix tests for markdown 3, upgrade graphviz package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ Markdown>=3.2,<3.8
 # explaining what was added or fixed (or at least pointing to the underlying
 # release notes of the bumped package).
 mkdocs-material==9.5.31
-markdown_inline_graphviz_extension==1.1.2
+markdown_inline_graphviz_extension@git+https://github.com/cesaremorel/markdown-inline-graphviz.git@v1.1.3
+# 
 mkdocs-monorepo-plugin==1.1.0
 plantuml-markdown==3.10.2
 mdx_truly_sane_lists==1.3

--- a/src/test_core.py
+++ b/src/test_core.py
@@ -98,7 +98,7 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         }
         rendered = template.render(config=config)
         as_json = json.loads(rendered)
-        self.assertEquals(config, as_json)
+        self.assertEqual(config, as_json)
 
     def test_restrict_snippet_base_path(self):
         self.mkdocs_yaml_config["mdx_configs"] = {

--- a/src/test_core.py
+++ b/src/test_core.py
@@ -88,7 +88,7 @@ class TestTechDocsCoreConfig(unittest.TestCase):
     def test_template_renders__multiline_value_as_valid_json(self):
         self.techdocscore.on_config(self.mkdocs_yaml_config)
         env = Environment(
-            loader=PackageLoader("test", self.techdocscore.tmp_dir_techdocs_theme.name),
+            loader=PackageLoader("src", self.techdocscore.tmp_dir_techdocs_theme.name),
             autoescape=select_autoescape(),
         )
         template = env.get_template("techdocs_metadata.json")


### PR DESCRIPTION
- **Upgrade graphviz extension**
- **assertEquals is a deprecated form of assertEqual**
- **Test module does not exist, use src**
