### PR TITLE
Fix duplicate parameters in stale action

### DIFF
--- a/.github/workflows/automate-stale.yml
+++ b/.github/workflows/automate-stale.yml
@@ -18,7 +18,6 @@ jobs:
           days-before-issue-stale: 60
           days-before-issue-close: 7
           exempt-issue-labels: after-vacations,will-fix
-          exempt-pr-labels: dependencies
           stale-issue-label: stale
           stale-pr-message: >
             This PR has been automatically marked as stale because it has not had
@@ -27,6 +26,6 @@ jobs:
             and we'll re-open the PR so that you can continue the contribution!
           days-before-pr-stale: 14
           days-before-pr-close: 7
-          exempt-pr-labels: after-vacations,will-fix
+          exempt-pr-labels: after-vacations,dependencies,will-fix
           stale-pr-label: stale
           operations-per-run: 100


### PR DESCRIPTION
Noticed this when I tested out Renovate:

```json

{
  "packageFile": ".github/workflows/automate-stale.yml"
  "err": {
    "message": "Failed to parse YAML file",
    "stack": "AggregateError: Failed to parse YAML file\n    at parseSingleYaml (/usr/local/renovate/lib/util/yaml.ts:127:11)\n    at extractWithYAMLParser (/usr/local/renovate/lib/modules/manager/github-actions/extract.ts:190:26)\n    at Object.extractPackageFile (/usr/local/renovate/lib/modules/manager/github-actions/extract.ts:227:8)\n    at extractPackageFile (/usr/local/renovate/lib/modules/manager/index.ts:75:9)\n    at getManagerPackageFiles (/usr/local/renovate/lib/workers/repository/extract/manager-files.ts:58:43)\n    at /usr/local/renovate/lib/workers/repository/extract/index.ts:57:28\n    at async Promise.all (index 0)\n    at extractAllDependencies (/usr/local/renovate/lib/workers/repository/extract/index.ts:54:26)\n    at extract (/usr/local/renovate/lib/workers/repository/process/extract-update.ts:140:28)\n    at extractDependencies (/usr/local/renovate/lib/workers/repository/process/index.ts:155:26)\n    at Object.renovateRepository (/usr/local/renovate/lib/workers/repository/index.ts:71:9)\n    at attributes.repository (/usr/local/renovate/lib/workers/global/index.ts:202:11)\n    at start (/usr/local/renovate/lib/workers/global/index.ts:187:7)\n    at /usr/local/renovate/lib/renovate.ts:18:22"
  }
}
```

Running then through yamllilnt:

![Screenshot 2024-11-08 at 10 16 02](https://github.com/user-attachments/assets/c3ff3ae9-df7c-421c-a651-a7d511f65627)
