### PR TITLE
Fix publish by installing setuptools

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,10 +23,11 @@ jobs:
         uses: actions/setup-python@master
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install pip, setuptools, and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
       - name: Build Python distribution
         working-directory: .
         run: |
-          pip install wheel
           rm -rf dist
           python setup.py bdist_wheel sdist --formats tar
           pushd dist >/dev/null || exit


### PR DESCRIPTION
This should fix the error in the release pipeline to get publishing working again.

Based this on what I found here in the docs: https://packaging.python.org/en/latest/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date