### PR TITLE
Add support for optional PyMdown blocks extension syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ plugins:
       use_material_search: true
 ```
 
+(Optional) To use [PyMdown Blocks Extensions](https://facelessuser.github.io/pymdown-extensions/extensions/blocks/api/) (replaces `admonitions`, `pymdownx.details` and `pymdownx.tabbed` extensions), you need to add the following configuration to your `mkdocs.yml`:
+
+```yaml
+plugins:
+  - techdocs-core:
+      use_pymdownx_blocks: true
+```
+
 ## Development
 
 ### Running Locally
@@ -148,6 +156,10 @@ build container).
 We only use `material-mkdocs` as base styles because Backstage also uses the `Material UI` on the client-side. We don't expect people to use themes other than `Material UI` to maintain consistency across all Backstage pages (in other words, documentation pages have the same look and feel as any other Backstage page) and so we use the `BackstageTheme` configured in Front-end application as the source of truth for all application design tokens like colors, typography and etc. So here you can [see](https://github.com/backstage/backstage/blob/master/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx#L160-L692) that some styles will always be overridden regardless of the `mkdocs-material` plugin theme settings and this can cause unexpected behavior for those who override the theme setting in a `mkdocs.yaml` file.
 
 ## Changelog
+
+### 1.5.3
+
+- Added support for PyMdown Blocks extensions
 
 ### 1.5.2
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ plugins:
       use_material_search: true
 ```
 
-(Optional) To use [PyMdown Blocks Extensions](https://facelessuser.github.io/pymdown-extensions/extensions/blocks/api/) (replaces `admonitions`, `pymdownx.details` and `pymdownx.tabbed` extensions), you need to add the following configuration to your `mkdocs.yml`:
+(Optional) To use [PyMdown Blocks Extensions](https://facelessuser.github.io/pymdown-extensions/extensions/blocks/) (replaces `admonitions`, `pymdownx.details` and `pymdownx.tabbed` extensions), you need to add the following configuration to your `mkdocs.yml`:
 
 ```yaml
 plugins:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.5.2",
+    version="1.5.3",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,

--- a/techdocs_core/core.py
+++ b/techdocs_core/core.py
@@ -1,17 +1,17 @@
 """
- * Copyright 2020 The Backstage Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+* Copyright 2020 The Backstage Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 """
 
 import tempfile
@@ -124,7 +124,7 @@ class TechDocsCore(BasePlugin):
                     "danger",
                     "bug",
                     "example",
-                    "quote"
+                    "quote",
                 ]
             }
             config["markdown_extensions"].append("pymdownx.blocks.details")
@@ -143,7 +143,7 @@ class TechDocsCore(BasePlugin):
                     {"name": "details-danger", "class": "danger"},
                     {"name": "details-bug", "class": "bug"},
                     {"name": "details-example", "class": "example"},
-                    {"name": "details-quote", "class": "quote"}
+                    {"name": "details-quote", "class": "quote"},
                 ]
             }
             config["markdown_extensions"].append("pymdownx.blocks.tab")

--- a/techdocs_core/core.py
+++ b/techdocs_core/core.py
@@ -79,6 +79,9 @@ class TechDocsCore(BasePlugin):
         use_material_search = config["plugins"]["techdocs-core"].config.get(
             "use_material_search", False
         )
+        use_pymdownx_blocks = config["plugins"]["techdocs-core"].config.get(
+            "use_pymdownx_blocks", False
+        )
         del config["plugins"]["techdocs-core"]
 
         if use_material_search:
@@ -99,15 +102,64 @@ class TechDocsCore(BasePlugin):
         if "mdx_configs" not in config:
             config["mdx_configs"] = {}
 
-        config["markdown_extensions"].append("admonition")
         config["markdown_extensions"].append("toc")
         config["mdx_configs"]["toc"] = {
             "permalink": True,
         }
 
+        if use_pymdownx_blocks:
+            config["markdown_extensions"].append("pymdownx.blocks.admonition")
+            config["mdx_configs"]["pymdownx.blocks.admonition"] = {
+                "types": [
+                    "new",
+                    "settings",
+                    "note",
+                    "abstract",
+                    "info",
+                    "tip",
+                    "success",
+                    "question",
+                    "warning",
+                    "failure",
+                    "danger",
+                    "bug",
+                    "example",
+                    "quote"
+                ]
+            }
+            config["markdown_extensions"].append("pymdownx.blocks.details")
+            config["mdx_configs"]["pymdownx.blocks.details"] = {
+                "types": [
+                    {"name": "details-new", "class": "new"},
+                    {"name": "details-settings", "class": "settings"},
+                    {"name": "details-note", "class": "note"},
+                    {"name": "details-abstract", "class": "abstract"},
+                    {"name": "details-info", "class": "info"},
+                    {"name": "details-tip", "class": "tip"},
+                    {"name": "details-success", "class": "success"},
+                    {"name": "details-question", "class": "question"},
+                    {"name": "details-warning", "class": "warning"},
+                    {"name": "details-failure", "class": "failure"},
+                    {"name": "details-danger", "class": "danger"},
+                    {"name": "details-bug", "class": "bug"},
+                    {"name": "details-example", "class": "example"},
+                    {"name": "details-quote", "class": "quote"}
+                ]
+            }
+            config["markdown_extensions"].append("pymdownx.blocks.tab")
+            config["mdx_configs"]["pymdownx.blocks.tab"] = {
+                "alternate_style": True,
+            }
+        else:
+            config["markdown_extensions"].append("admonition")
+            config["markdown_extensions"].append("pymdownx.details")
+            config["markdown_extensions"].append("pymdownx.tabbed")
+            config["mdx_configs"]["pymdownx.tabbed"] = {
+                "alternate_style": True,
+            }
+
         config["markdown_extensions"].append("pymdownx.caret")
         config["markdown_extensions"].append("pymdownx.critic")
-        config["markdown_extensions"].append("pymdownx.details")
         config["markdown_extensions"].append("pymdownx.emoji")
         config["mdx_configs"]["pymdownx.emoji"] = {"emoji_generator": to_svg}
         config["markdown_extensions"].append("pymdownx.inlinehilite")
@@ -123,10 +175,6 @@ class TechDocsCore(BasePlugin):
         config["markdown_extensions"].append("pymdownx.extra")
         config["mdx_configs"]["pymdownx.betterem"] = {
             "smart_enable": "all",
-        }
-        config["markdown_extensions"].append("pymdownx.tabbed")
-        config["mdx_configs"]["pymdownx.tabbed"] = {
-            "alternate_style": True,
         }
         config["markdown_extensions"].append("pymdownx.tasklist")
         config["mdx_configs"]["pymdownx.tasklist"] = {

--- a/techdocs_core/test_core.py
+++ b/techdocs_core/test_core.py
@@ -138,12 +138,22 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         )
         final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
 
-        self.assertTrue("pymdownx.blocks.admonition" in final_config["markdown_extensions"])
-        self.assertTrue("pymdownx.blocks.details" in final_config["markdown_extensions"])
+        self.assertTrue(
+            "pymdownx.blocks.admonition" in final_config["markdown_extensions"]
+        )
+        self.assertTrue(
+            "pymdownx.blocks.details" in final_config["markdown_extensions"]
+        )
         self.assertTrue("pymdownx.blocks.tab" in final_config["markdown_extensions"])
-        self.assertTrue("types" in final_config["mdx_configs"]["pymdownx.blocks.admonition"])
-        self.assertTrue("types" in final_config["mdx_configs"]["pymdownx.blocks.details"])
-        self.assertTrue("alternate_style" in final_config["mdx_configs"]["pymdownx.blocks.tab"])
+        self.assertTrue(
+            "types" in final_config["mdx_configs"]["pymdownx.blocks.admonition"]
+        )
+        self.assertTrue(
+            "types" in final_config["mdx_configs"]["pymdownx.blocks.details"]
+        )
+        self.assertTrue(
+            "alternate_style" in final_config["mdx_configs"]["pymdownx.blocks.tab"]
+        )
         self.assertFalse("admonition" in final_config["markdown_extensions"])
         self.assertFalse("pymdownx.details" in final_config["markdown_extensions"])
         self.assertFalse("pymdownx.tabbed" in final_config["markdown_extensions"])
@@ -153,8 +163,12 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.plugin_collection["techdocs-core"].load_config({})
         final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
 
-        self.assertFalse("pymdownx.blocks.admonition" in final_config["markdown_extensions"])
-        self.assertFalse("pymdownx.blocks.details" in final_config["markdown_extensions"])
+        self.assertFalse(
+            "pymdownx.blocks.admonition" in final_config["markdown_extensions"]
+        )
+        self.assertFalse(
+            "pymdownx.blocks.details" in final_config["markdown_extensions"]
+        )
         self.assertFalse("pymdownx.blocks.tab" in final_config["markdown_extensions"])
         self.assertFalse("pymdownx.blocks.admonition" in final_config["mdx_configs"])
         self.assertFalse("pymdownx.blocks.details" in final_config["mdx_configs"])
@@ -162,4 +176,6 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertTrue("admonition" in final_config["markdown_extensions"])
         self.assertTrue("pymdownx.details" in final_config["markdown_extensions"])
         self.assertTrue("pymdownx.tabbed" in final_config["markdown_extensions"])
-        self.assertTrue("alternate_style" in final_config["mdx_configs"]["pymdownx.tabbed"])
+        self.assertTrue(
+            "alternate_style" in final_config["mdx_configs"]["pymdownx.tabbed"]
+        )

--- a/techdocs_core/test_core.py
+++ b/techdocs_core/test_core.py
@@ -131,3 +131,35 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertEqual(
             final_config["plugins"]["search"].__module__, "mkdocs.contrib.search"
         )
+
+    def test_pymdownx_blocks(self):
+        self.plugin_collection["techdocs-core"].load_config(
+            {"use_pymdownx_blocks": True}
+        )
+        final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
+
+        self.assertTrue("pymdownx.blocks.admonition" in final_config["markdown_extensions"])
+        self.assertTrue("pymdownx.blocks.details" in final_config["markdown_extensions"])
+        self.assertTrue("pymdownx.blocks.tab" in final_config["markdown_extensions"])
+        self.assertTrue("types" in final_config["mdx_configs"]["pymdownx.blocks.admonition"])
+        self.assertTrue("types" in final_config["mdx_configs"]["pymdownx.blocks.details"])
+        self.assertTrue("alternate_style" in final_config["mdx_configs"]["pymdownx.blocks.tab"])
+        self.assertFalse("admonition" in final_config["markdown_extensions"])
+        self.assertFalse("pymdownx.details" in final_config["markdown_extensions"])
+        self.assertFalse("pymdownx.tabbed" in final_config["markdown_extensions"])
+        self.assertFalse("pymdownx.tabbed" in final_config["mdx_configs"])
+
+    def test_default_pymdownx(self):
+        self.plugin_collection["techdocs-core"].load_config({})
+        final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
+
+        self.assertFalse("pymdownx.blocks.admonition" in final_config["markdown_extensions"])
+        self.assertFalse("pymdownx.blocks.details" in final_config["markdown_extensions"])
+        self.assertFalse("pymdownx.blocks.tab" in final_config["markdown_extensions"])
+        self.assertFalse("pymdownx.blocks.admonition" in final_config["mdx_configs"])
+        self.assertFalse("pymdownx.blocks.details" in final_config["mdx_configs"])
+        self.assertFalse("pymdownx.blocks.tab" in final_config["mdx_configs"])
+        self.assertTrue("admonition" in final_config["markdown_extensions"])
+        self.assertTrue("pymdownx.details" in final_config["markdown_extensions"])
+        self.assertTrue("pymdownx.tabbed" in final_config["markdown_extensions"])
+        self.assertTrue("alternate_style" in final_config["mdx_configs"]["pymdownx.tabbed"])


### PR DESCRIPTION
PyMdown has support for non-indentation dependent objects like admonitions, details and tabs. In their documentation they specify that this blocks syntax is not intended to be used in conjunction with the non-blocks variation. 

> The new pymdownx.blocks.admonition extension is meant to replace admonition, they are not meant to be used together. Their output is identical making it easy to transition by simply swapping out the syntax, but using them both together can cause issues as they both generate the same output and confuse each other.
> 
> If you are switching from admonition to pymdownx.blocks.admonition, ensure you disable admonition to avoid issues.

Read more about the blocks extension in the [PyMdown docs](https://facelessuser.github.io/pymdown-extensions/extensions/blocks/)

I added a new property to the `techdocs-core` plugin called `use_pymdownx_blocks` that disables:

- `admonition`
- `pymdownx.details`
- `pymdownx.tabbed`
 
and enables:

- `pymdownx.blocks.admonition`
- `pymdownx.blocks.details`
- `pymdownx.blocks.tab`


The default for the new property is false, so all existing documentation will be unchanged.