### PR TITLE
Update graphviz dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ We only use `material-mkdocs` as base styles because Backstage also uses the `Ma
 
 ## Changelog
 
+### 1.5.2
+
+- Update `markdown_inline_graphviz_extension` to use forked `markdown-graphviz-inline` instead due to abandonment of original dependency.
+
 ### 1.5.1
 
 - Minimum supported Python version is now 3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Markdown>=3.2,<3.8
 # explaining what was added or fixed (or at least pointing to the underlying
 # release notes of the bumped package).
 mkdocs-material==9.5.49
-markdown_inline_graphviz_extension@git+https://github.com/cesaremorel/markdown-inline-graphviz.git@579f10af9fe7187c717c20615f65774f898c1a0d
+markdown-graphviz-inline==1.1.3
 mkdocs-monorepo-plugin==1.1.0
 plantuml-markdown==3.10.4
 mdx_truly_sane_lists==1.3

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.5.1",
+    version="1.5.2",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
Uses a [fork under backstage](https://github.com/backstage/markdown-inline-graphviz) of [markdown-inline-graphviz](https://github.com/cesaremorel/markdown-inline-graphviz) instead due to abandonment of original dependency.

Closes https://github.com/backstage/mkdocs-techdocs-core/issues/244