### PR TITLE
fix: eliminate configuration warnings for techdocs-core options

### DIFF
--- a/techdocs_core/core.py
+++ b/techdocs_core/core.py
@@ -15,9 +15,9 @@
 """
 
 import tempfile
-import logging
 import os
-from mkdocs.plugins import BasePlugin
+from mkdocs.plugins import BasePlugin, get_plugin_logger
+from mkdocs.config import base, config_options as c
 from mkdocs.theme import Theme
 from mkdocs.contrib.search import SearchPlugin
 from material.plugins.search.plugin import SearchPlugin as MaterialSearchPlugin
@@ -25,12 +25,17 @@ from mkdocs_monorepo_plugin.plugin import MonorepoPlugin
 from pymdownx.emoji import to_svg
 from pymdownx.extra import extra_extensions
 
-log = logging.getLogger(__name__)
+log = get_plugin_logger(__name__)
 
 TECHDOCS_DEFAULT_THEME = "material"
 
 
-class TechDocsCore(BasePlugin):
+class TechDocsCoreConfig(base.Config):
+    use_material_search = c.Type(bool, default=False)
+    use_pymdownx_blocks = c.Type(bool, default=False)
+
+
+class TechDocsCore(BasePlugin[TechDocsCoreConfig]):
     def __init__(self):
         # This directory will be removed automatically once the docs are built
         # MkDocs needs a directory for the theme with the `techdocs_metadata.json` file
@@ -76,12 +81,11 @@ class TechDocsCore(BasePlugin):
         config["theme"].dirs.append(self.tmp_dir_techdocs_theme.name)
 
         # Plugins
-        use_material_search = config["plugins"]["techdocs-core"].config.get(
-            "use_material_search", False
-        )
-        use_pymdownx_blocks = config["plugins"]["techdocs-core"].config.get(
-            "use_pymdownx_blocks", False
-        )
+        use_material_search = self.config.use_material_search
+        use_pymdownx_blocks = self.config.use_pymdownx_blocks
+
+        log.info("[mkdocs-techdocs-core] Plugin configuration: %s", self.config)
+
         del config["plugins"]["techdocs-core"]
 
         if use_material_search:

--- a/techdocs_core/test_core.py
+++ b/techdocs_core/test_core.py
@@ -12,25 +12,22 @@ def get_default_theme():
     return Theme(name="mkdocs")
 
 
-class DummyTechDocsCorePlugin(plugins.BasePlugin):
-    pass
-
-
 class TestTechDocsCoreConfig(unittest.TestCase):
     def setUp(self):
         self.techdocscore = TechDocsCore()
         self.plugin_collection = plugins.PluginCollection()
-        plugin = DummyTechDocsCorePlugin()
-        self.plugin_collection["techdocs-core"] = plugin
+        self.plugin_collection["techdocs-core"] = self.techdocscore
         self.mkdocs_yaml_config = {"plugins": self.plugin_collection}
         # Note: in reality, config["theme"] is always an instance of Theme
         self.mkdocs_yaml_config["theme"] = get_default_theme()
 
     def test_removes_techdocs_core_plugin_from_config(self):
+        self.plugin_collection["techdocs-core"].load_config({})
         final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
         self.assertTrue("techdocs-core" not in final_config["plugins"])
 
     def test_merge_default_config_and_user_config(self):
+        self.plugin_collection["techdocs-core"].load_config({})
         self.mkdocs_yaml_config["markdown_extension"] = []
         self.mkdocs_yaml_config["mdx_configs"] = {}
         self.mkdocs_yaml_config["markdown_extension"].append(["toc"])
@@ -42,6 +39,7 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertTrue("mdx_truly_sane_lists" in final_config["markdown_extensions"])
 
     def test_override_default_config_with_user_config(self):
+        self.plugin_collection["techdocs-core"].load_config({})
         self.mkdocs_yaml_config["markdown_extension"] = []
         self.mkdocs_yaml_config["mdx_configs"] = {}
         self.mkdocs_yaml_config["markdown_extension"].append(["toc"])
@@ -53,6 +51,7 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertTrue("mdx_truly_sane_lists" in final_config["markdown_extensions"])
 
     def test_theme_overrides_removed_when_name_is_not_material(self):
+        self.plugin_collection["techdocs-core"].load_config({})
         # we want to force the theme mkdocs to this test
         self.mkdocs_yaml_config["theme"] = Theme(name="mkdocs")
         self.mkdocs_yaml_config["theme"]["features"] = ["navigation.sections"]
@@ -60,12 +59,14 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertFalse("navigation.sections" in final_config["theme"]["features"])
 
     def test_theme_overrides_when_name_is_material(self):
+        self.plugin_collection["techdocs-core"].load_config({})
         self.mkdocs_yaml_config["theme"] = Theme(name=TECHDOCS_DEFAULT_THEME)
         self.mkdocs_yaml_config["theme"]["features"] = ["navigation.sections"]
         final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
         self.assertTrue("navigation.sections" in final_config["theme"]["features"])
 
     def test_theme_overrides_techdocs_metadata(self):
+        self.plugin_collection["techdocs-core"].load_config({})
         self.mkdocs_yaml_config["theme"] = Theme(
             name=TECHDOCS_DEFAULT_THEME, static_templates=["my_static_temples"]
         )
@@ -76,6 +77,7 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         )
 
     def test_theme_overrides_dirs(self):
+        self.plugin_collection["techdocs-core"].load_config({})
         custom_theme_dir = "/tmp/my_custom_theme_dir"
         self.mkdocs_yaml_config["theme"] = Theme(name=TECHDOCS_DEFAULT_THEME)
         self.mkdocs_yaml_config["theme"].dirs.append(custom_theme_dir)
@@ -86,6 +88,7 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         )
 
     def test_template_renders__multiline_value_as_valid_json(self):
+        self.plugin_collection["techdocs-core"].load_config({})
         self.techdocscore.on_config(self.mkdocs_yaml_config)
         env = Environment(
             loader=PackageLoader(
@@ -103,6 +106,7 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertEqual(config, as_json)
 
     def test_restrict_snippet_base_path(self):
+        self.plugin_collection["techdocs-core"].load_config({})
         self.mkdocs_yaml_config["mdx_configs"] = {
             "pymdownx.snippets": {"restrict_base_path": False}
         }


### PR DESCRIPTION
Declare `use_material_search` and `use_pymdownx_blocks` in a type-safe config class to prevent MkDocs from emitting warnings about unrecognized options in mkdocs.yml. This follows MkDocs 1.4+ best practices and ensures proper
validation.

### Note to the reviewer
I don't really know Python nor have I developed MkDocs plug-ins. I did however reference the [docs](https://www.mkdocs.org/dev-guide/plugins/). 
I also chose to use the type-safe variant recommended for MkDocs 1.4+ considering that `mkdocs-techdocs-core` requires MkDocs 1.6+. On that note, the code could be refactored to use the typesafe configuration in `on_config` as well.

The tests run green (after minor changes to actually call `load_config` in all cases) and I've successully tested the modified package on my own project. Nevertheless I hope someone experienced can validated this change.

Fixes #262