### PR TITLE
🆙 Version Bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="1.5.4",
+    version="1.5.5",
     description="The core MkDocs plugin used by Backstage's TechDocs as a wrapper around "
     "multiple MkDocs plugins and Python Markdown extensions",
     long_description=long_description,


### PR DESCRIPTION
In order to publish the changes to transitive deps over the past 3 months, we need to release a new version of mkdocs-techdocs-core