### PR TITLE
ci: use app token for semantic release workflow

### DIFF
--- a/.github/workflows/manual-versioning.yml
+++ b/.github/workflows/manual-versioning.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - name: "Generate token"
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private_key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Replace GITHUB_TOKEN with generated app token to ensure proper permissions for semantic release operations