### PR TITLE
fix(publishing): corrected license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "1.6.0"
 description = """The core MkDocs plugin used by Backstage's TechDocs as a wrapper around multiple MkDocs plugins and Python Markdown extensions"""
 readme = "README.md"
 requires-python = ">=3.9"
-license-files = ["LICENSE"]
+license = "Apache-2.0"
 keywords = ["mkdocs"]
 authors = [
     {name = "TechDocs Core", email = "protean@spotify.com"}


### PR DESCRIPTION
This changes adds the license to the `pyproject.toml` in the same way we had it previously in the `setup.py` file as seen here: https://github.com/backstage/mkdocs-techdocs-core/commit/2975ca9f56a740f5f6c081d2e8d5b1da863059df#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L40

What we have in place right now [should work according to the docs](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files) but this seems like the simplest fix as we don't have an easy way to test publishing end to end.

This fixes #302 