### PR TITLE
fix: loosen pygments dependency to >=2.16 to allow CVE-2026-4539 fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # packages that might otherwise exist in an adopter's environment.
 mkdocs>=1.6
 Markdown>=3.2,<3.11
+pygments>=2.16
 
 # The following are more akin to direct dependencies. Each line represents one
 # or more features that are provided by `techdocs-core`, and thus are always
@@ -15,7 +16,6 @@ mkdocs-monorepo-plugin==1.1.2
 plantuml-markdown==3.11.1
 mdx_truly_sane_lists==1.3
 pymdown-extensions==10.21
-pygments==2.19.2
 mkdocs-redirects==1.2.2
 
 # The following are temporary dependencies that are only necessary to work


### PR DESCRIPTION
## Summary

Moves `pygments` from an exact pin (`==2.19.2`) to a range constraint (`>=2.16`) in the peer dependencies section of `requirements.txt`.

## Motivation

`pygments 2.20.0` was released to fix [CVE-2026-4539](https://www.cve.org/CVERecord?id=CVE-2026-4539). The previous exact pin prevented downstream projects from upgrading to the patched release, causing `pip-audit` to flag the vulnerability with no available workaround.

## Changes

- Moved `pygments` from the "direct dependencies" section (exact pin) to the "peer dependencies" section (range), consistent with how `mkdocs` and `Markdown` are already handled.
- The lower bound `>=2.16` matches `mkdocs-material`'s own requirement for pygments.
- `pygments` is not directly imported by `techdocs-core` — it's a transitive dependency of `mkdocs-material` (hard dep) and `pymdown-extensions` (optional extra). A range constraint is more appropriate than an exact pin.

Fixes #334