### PR TITLE
feat: include gh-admonitions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ TechDocs Core plugin:
 
 - [search](https://www.mkdocs.org/user-guide/configuration/#search): A search plugin is provided by default with MkDocs which uses [lunr.js](https://lunrjs.com/) as a search engine.
 - [mkdocs-monorepo-plugin](https://github.com/backstage/mkdocs-monorepo-plugin): This plugin enables you to build multiple sets of documentation in a single MkDocs project. It is designed to address writing documentation in Spotify's largest and most business-critical codebases (typically monoliths or monorepos).
+- [gh-admonitions](https://github.com/PGijsbers/admonitions): This plugin converts GitHub alert syntax, such as `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, and `> [!CAUTION]`, to MkDocs Material admonitions.
 
 **Extensions**:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ Markdown>=3.2,<3.11
 # release notes of the bumped package).
 mkdocs-material==9.7.6
 markdown-graphviz-inline==1.1.3
+mkdocs-github-admonitions-plugin==0.1.1
 mkdocs-monorepo-plugin==1.1.2
 plantuml-markdown==3.11.2
 mdx_truly_sane_lists==1.3

--- a/techdocs_core/core.py
+++ b/techdocs_core/core.py
@@ -22,6 +22,7 @@ from mkdocs.config import Config, config_options
 from mkdocs.plugins import BasePlugin
 from mkdocs.theme import Theme
 from mkdocs.contrib.search import SearchPlugin
+from admonitions.admonition import AdmonitionConverter
 from material.plugins.search.plugin import SearchPlugin as MaterialSearchPlugin
 from mkdocs_monorepo_plugin.plugin import MonorepoPlugin
 from pymdownx.emoji import to_svg
@@ -95,8 +96,11 @@ class TechDocsCore(BasePlugin[TechDocsCoreConfig]):
 
         monorepo_plugin = MonorepoPlugin()
         monorepo_plugin.load_config({})
+        gh_admonitions_plugin = AdmonitionConverter()
+        gh_admonitions_plugin.load_config({})
         config["plugins"]["search"] = search_plugin
         config["plugins"]["monorepo"] = monorepo_plugin
+        config["plugins"]["gh-admonitions"] = gh_admonitions_plugin
 
         # Markdown Extensions
         if "markdown_extensions" not in config:

--- a/techdocs_core/test_core.py
+++ b/techdocs_core/test_core.py
@@ -129,6 +129,18 @@ class TestTechDocsCore(unittest.TestCase):
             final_config["plugins"]["search"].__module__, "mkdocs.contrib.search"
         )
 
+    def test_gh_admonitions(self):
+        final_config = self.techdocscore.on_config(self.techdocscore.config)
+
+        self.assertEqual(
+            final_config["plugins"]["gh-admonitions"].__module__,
+            "admonitions.admonition",
+        )
+        self.assertEqual(
+            final_config["plugins"]["gh-admonitions"].__class__.__name__,
+            "AdmonitionConverter",
+        )
+
     def test_pymdownx_blocks(self):
         self.techdocscore.config["use_pymdownx_blocks"] = True
         final_config = self.techdocscore.on_config(self.techdocscore.config)


### PR DESCRIPTION
## Summary

Adds `gh-admonitions` as a default bundled MkDocs plugin in `mkdocs-techdocs-core`.

This enables GitHub alert syntax such as `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, and `> [!CAUTION]` to render as MkDocs Material admonitions without requiring TechDocs users to configure the plugin separately.

## Changes

- Added `mkdocs-github-admonitions-plugin==0.1.1` as a pinned dependency.
- Registered the `gh-admonitions` plugin by default from `techdocs-core`.
- Added unit coverage confirming the plugin is injected into the MkDocs plugin config.
- Updated the README plugin list to document the new bundled plugin.

## Testing

- `python -m unittest techdocs_core/test_core.py`
- `pip install --editable .`
- `mkdocs build --config-file test-fixtures/mkdocs.yml`
- `black --check .`
