### PR TITLE
Fix validate-renovate workflow path drift (.json5 → .json)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate configuration for mkdocs-techdocs-core. Validated by .github/workflows/validate-renovate.yml on every PR that touches this file.",
 
   "extends": [
     "config:recommended",

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/renovate.json5'
+      - '.github/renovate.json'
 
 jobs:
   validate:
@@ -17,4 +17,4 @@ jobs:
       - name: Validate
         uses: rinchsan/renovate-config-validator@v0.2.1
         with:
-          pattern: '*.json5'
+          pattern: '.github/renovate.json'


### PR DESCRIPTION
## What

The `validate-renovate.yml` workflow is wired to a filename that doesn't exist in this repo, so the Renovate config has effectively been unvalidated on PRs.

Two mismatches in `.github/workflows/validate-renovate.yml`:

1. **`paths:` filter** targeted `.github/renovate.json5`, but the on-disk config is `.github/renovate.json`. PRs touching the config never triggered the workflow.
2. **Validator step** used `pattern: '*.json5'`, which matches no files in the repo.

Both now point at `.github/renovate.json`, the actual config filename.

## Why this direction (`.json` rather than renaming to `.json5`)

`.json5` is Renovate's preferred format, but the existing `renovate.json` uses no JSON5-only syntax (no comments, no trailing commas, no unquoted keys). Renaming would be a stylistic migration with no functional benefit and a larger diff. The smaller, safer fix is to align the workflow with the file that already exists.

## Verifying it runs

Touched `.github/renovate.json` with a no-op `"description"` field so this PR exercises the `paths:` filter and you can see the workflow trigger and pass green. The field is semantically inert for Renovate; it just documents that the file is validated on PR.

## Scope

- No behavioural change to Renovate itself — same `extends`, same `packageRules`.
- Out of scope: any other rule/schedule changes to the Renovate config.
- Noted in passing (not fixed here): the per-project review also flagged this drift alongside other small CI hygiene items in the repo — happy to follow up separately if useful.

## Context

Came out of a project-level repo review rather than a GitHub issue. Companion small-fix PR to `backstage/charts` #326 (the dual-stack Helm-doc README fix), part of the same review pass.
