### PR TITLE
deps: click range & advertised Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the base [Mkdocs](https://mkdocs.org) plugin used when using Mkdocs with
 
 ## Usage
 
-> Requires Python version >= 3.8
+> Requires Python version >= 3.9
 
 ```bash
 $ pip install mkdocs-techdocs-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,8 @@ mkdocs-redirects==1.2.3
 # around incompatible/conflicting underlying dependencies. Each dependency
 # should include a comment explaining why it is needed, and under what
 # circumstances it can be removed in the future.
-# Pinned click to avoid issues with autoreload https://github.com/squidfunk/mkdocs-material/issues/8478
-click<=8.4.2
+# Exclude click 8.3.* which broke mkdocs serve autoreload (fixed in 8.4.0).
+# Other bounds are inherited from transitive deps (e.g. mkdocs).
+# https://github.com/squidfunk/mkdocs-material/issues/8478
+# https://github.com/pallets/click/issues/3403
+click!=8.3.*


### PR DESCRIPTION
Hey @awalin,

Just a small update to:

- align the docs with the Python version declared in pyproject.toml (& required by dependencies like pymdown-extensions)
- remove the click upper-range, which is not required anymore and is generating renovate churn with bumps
  - In #321 I set an upper-range as we didn't know when the dependency was going to be fixed, we now know that only 8.3.* breaks the auto-reload.
  - the current range could (theoretically) allow a broken click version to be installed, which is counter-productive

Thanks again for all your work! 